### PR TITLE
✨ [FEAT] #1: 디자인 시스템 설정

### DIFF
--- a/app/src/main/java/com/umc/phrase/MainActivity.kt
+++ b/app/src/main/java/com/umc/phrase/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.umc.phrase.ui.theme.PhraseTheme
+import com.umc.phrase.commons.ui.theme.PhraseTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/umc/phrase/commons/ui/component/Button.kt
+++ b/app/src/main/java/com/umc/phrase/commons/ui/component/Button.kt
@@ -1,0 +1,184 @@
+package com.umc.phrase.commons.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.umc.phrase.commons.ui.theme.PhraseTheme
+
+@Composable
+fun BasicButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = false,
+    onClick: () -> Unit,
+    colors: ButtonColors = ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.surfaceVariant,
+        disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+        disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+    ),
+    textStyle: TextStyle = MaterialTheme.typography.displayMedium
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RoundedCornerShape(10.dp),
+        colors = colors,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = text,
+            style = textStyle
+        )
+    }
+}
+
+enum class DeleteButtonStyle {
+    DEFAULT, HIGHLIGHTED
+}
+
+@Composable
+fun SecondaryButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = false,
+    onClick: () -> Unit
+) {
+    BasicButton(
+        text = text,
+        modifier = modifier,
+        enabled = enabled,
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.primary,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        ),
+        textStyle = MaterialTheme.typography.titleMedium
+    )
+}
+
+@Composable
+fun DeleteButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: DeleteButtonStyle = DeleteButtonStyle.DEFAULT
+) {
+    val backgroundColor = when (style) {
+        DeleteButtonStyle.DEFAULT -> MaterialTheme.colorScheme.surfaceVariant
+        DeleteButtonStyle.HIGHLIGHTED -> MaterialTheme.colorScheme.errorContainer
+    }
+
+    val iconColor = when (style) {
+        DeleteButtonStyle.DEFAULT -> MaterialTheme.colorScheme.onSurfaceVariant
+        DeleteButtonStyle.HIGHLIGHTED -> MaterialTheme.colorScheme.error
+    }
+
+    Box(
+        modifier = modifier
+            .size(20.dp)
+            .background(color = backgroundColor, shape = CircleShape)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = "Delete",
+            tint = iconColor
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BasicButtonPreview1() {
+    PhraseTheme {
+        Column(
+            modifier = Modifier.padding(10.dp)
+        ) {
+            BasicButton(
+                text = "시작하기",
+                enabled = false,
+                onClick = {}
+            )
+
+            BasicButton(
+                text = "시작하기",
+                enabled = true,
+                onClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BasicButtonPreview2() {
+    PhraseTheme {
+        Column(
+            modifier = Modifier.padding(10.dp)
+        ) {
+            BasicButton(
+                text = "팔로잉",
+                enabled = false,
+                onClick = {},
+                textStyle = MaterialTheme.typography.titleMedium
+            )
+
+            BasicButton(
+                text = "팔로우",
+                enabled = true,
+                onClick = {},
+                textStyle = MaterialTheme.typography.titleMedium
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SecondaryButtonPreview1() {
+    PhraseTheme {
+        Row(
+            modifier = Modifier.padding(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            SecondaryButton(
+                text = "프로필 편집",
+                enabled = true,
+                onClick = {},
+                modifier = Modifier.weight(1f)
+            )
+
+            SecondaryButton(
+                text = "프로필 공유",
+                enabled = true,
+                onClick = {},
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/umc/phrase/commons/ui/component/InputField.kt
+++ b/app/src/main/java/com/umc/phrase/commons/ui/component/InputField.kt
@@ -40,13 +40,13 @@ enum class BorderType {
 }
 
 @Composable
-fun BasicInputField(
+fun BasicTextField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     placeholder: String = "",
     placeholderStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
-    textStyle: TextStyle = MaterialTheme.typography.titleMedium.copy(color = MaterialTheme.colorScheme.onBackground),
+    textStyle: TextStyle = MaterialTheme.typography.titleMedium,
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
     validateInput: ((String) -> BorderType)? = null,
     errorMessage: String? = null,
@@ -72,12 +72,6 @@ fun BasicInputField(
         BorderType.ERROR -> MaterialTheme.colorScheme.error
     }
 
-    val textColor = when (borderType) {
-        BorderType.SUCCESS -> MaterialTheme.colorScheme.primary
-        BorderType.ERROR -> MaterialTheme.colorScheme.error
-        else -> textStyle.color
-    }
-
     val verticalAlignment = if (singleLine) {
         Alignment.CenterVertically
     } else {
@@ -85,15 +79,14 @@ fun BasicInputField(
     }
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        BasicTextField(
-            value = value,
+        BasicTextField(value = value,
             onValueChange = {
                 if (maxLength == null || it.length <= maxLength) {
                     onValueChange(it)
                 }
             },
             modifier = modifier.fillMaxWidth(),
-            textStyle = textStyle.copy(color = textColor),
+            textStyle = textStyle.copy(color = MaterialTheme.colorScheme.onBackground),
             singleLine = singleLine,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
@@ -104,9 +97,7 @@ fun BasicInputField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .border(
-                            width = 1.dp,
-                            color = borderColor,
-                            shape = MaterialTheme.shapes.small
+                            width = 1.dp, color = borderColor, shape = MaterialTheme.shapes.small
                         )
                         .background(color = backgroundColor, shape = MaterialTheme.shapes.small)
                         .padding(15.dp)
@@ -120,8 +111,7 @@ fun BasicInputField(
                             Text(
                                 text = placeholder,
                                 style = placeholderStyle,
-                                modifier = Modifier
-                                    .align(Alignment.CenterStart)
+                                modifier = Modifier.align(Alignment.CenterStart)
                             )
                         }
                         innerTextField()
@@ -146,7 +136,7 @@ fun BasicInputField(
 }
 
 @Composable
-fun CleanableInputField(
+fun CleanableTextField(
     value: String,
     onValueChange: (String) -> Unit,
     onClear: () -> Unit = { onValueChange("") },
@@ -156,8 +146,7 @@ fun CleanableInputField(
     maxLength: Int? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None
 ) {
-    BasicInputField(
-        value = value,
+    BasicTextField(value = value,
         onValueChange = onValueChange,
         placeholder = placeholder,
         validateInput = validateInput,
@@ -167,23 +156,20 @@ fun CleanableInputField(
         trailingIcon = {
             if (value.isNotEmpty()) {
                 DeleteButton(
-                    onClick = onClear,
-                    style = DeleteButtonStyle.DEFAULT
+                    onClick = onClear, style = DeleteButtonStyle.DEFAULT
                 )
             }
-        }
-    )
+        })
 }
 
 @Composable
-fun SearchInputField(
+fun SearchBar(
     value: String,
     onValueChange: (String) -> Unit,
     onSearch: () -> Unit,
     placeholder: String = "",
 ) {
-    BasicInputField(
-        value = value,
+    BasicTextField(value = value,
         onValueChange = onValueChange,
         placeholder = placeholder,
         backgroundColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -198,8 +184,7 @@ fun SearchInputField(
                     .clickable { onSearch() },
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
-        }
-    )
+        })
 }
 
 @Preview(showBackground = true)
@@ -209,10 +194,9 @@ fun InputFieldPreview() {
 
     PhraseTheme {
         Column(
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-            modifier = Modifier.padding(10.dp)
+            verticalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.padding(10.dp)
         ) {
-            BasicInputField(
+            BasicTextField(
                 value = text,
                 onValueChange = { text = it },
                 validateInput = { _ ->
@@ -220,11 +204,10 @@ fun InputFieldPreview() {
                 },
                 singleLine = false,
                 placeholder = "내용을 입력해주세요.",
-                modifier = Modifier
-                    .size(width = 500.dp, height = 300.dp)
+                modifier = Modifier.size(width = 500.dp, height = 300.dp)
             )
 
-            BasicInputField(
+            BasicTextField(
                 value = text,
                 onValueChange = { text = it },
                 validateInput = { input ->
@@ -238,7 +221,7 @@ fun InputFieldPreview() {
                 placeholder = "닉네임을 입력해주세요.",
             )
 
-            BasicInputField(
+            BasicTextField(
                 value = text,
                 onValueChange = { text = it },
                 validateInput = { input ->
@@ -253,7 +236,7 @@ fun InputFieldPreview() {
                 visualTransformation = PasswordVisualTransformation()
             )
 
-            CleanableInputField(
+            CleanableTextField(
                 value = text,
                 onValueChange = { text = it },
                 validateInput = { input ->
@@ -267,7 +250,7 @@ fun InputFieldPreview() {
                 placeholder = "닉네임을 입력해주세요."
             )
 
-            SearchInputField(
+            SearchBar(
                 value = text,
                 onValueChange = { text = it },
                 onSearch = { /* Search action */ },

--- a/app/src/main/java/com/umc/phrase/commons/ui/component/InputField.kt
+++ b/app/src/main/java/com/umc/phrase/commons/ui/component/InputField.kt
@@ -1,0 +1,278 @@
+package com.umc.phrase.commons.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.umc.phrase.commons.ui.theme.PhraseTheme
+
+enum class BorderType {
+    NONE, NORMAL, SUCCESS, ERROR
+}
+
+@Composable
+fun BasicInputField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    placeholderStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
+    textStyle: TextStyle = MaterialTheme.typography.titleMedium.copy(color = MaterialTheme.colorScheme.onBackground),
+    backgroundColor: Color = MaterialTheme.colorScheme.surface,
+    validateInput: ((String) -> BorderType)? = null,
+    errorMessage: String? = null,
+    maxLength: Int? = null,
+    singleLine: Boolean = true,
+    trailingIcon: (@Composable () -> Unit)? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None
+) {
+    var borderType by remember { mutableStateOf(BorderType.NONE) }
+
+    LaunchedEffect(value) {
+        validateInput?.let { validator ->
+            borderType = validator(value)
+        }
+    }
+
+    val borderColor = when (borderType) {
+        BorderType.NONE -> backgroundColor
+        BorderType.NORMAL -> MaterialTheme.colorScheme.outline
+        BorderType.SUCCESS -> MaterialTheme.colorScheme.primary
+        BorderType.ERROR -> MaterialTheme.colorScheme.error
+    }
+
+    val textColor = when (borderType) {
+        BorderType.SUCCESS -> MaterialTheme.colorScheme.primary
+        BorderType.ERROR -> MaterialTheme.colorScheme.error
+        else -> textStyle.color
+    }
+
+    val verticalAlignment = if (singleLine) {
+        Alignment.CenterVertically
+    } else {
+        Alignment.Top
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        BasicTextField(
+            value = value,
+            onValueChange = {
+                if (maxLength == null || it.length <= maxLength) {
+                    onValueChange(it)
+                }
+            },
+            modifier = modifier.fillMaxWidth(),
+            textStyle = textStyle.copy(color = textColor),
+            singleLine = singleLine,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            visualTransformation = visualTransformation,
+            decorationBox = { innerTextField ->
+                Row(
+                    verticalAlignment = verticalAlignment,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = borderColor,
+                            shape = MaterialTheme.shapes.small
+                        )
+                        .background(color = backgroundColor, shape = MaterialTheme.shapes.small)
+                        .padding(15.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = placeholder,
+                                style = placeholderStyle,
+                                modifier = Modifier
+                                    .align(Alignment.CenterStart)
+                            )
+                        }
+                        innerTextField()
+                    }
+
+                    if (trailingIcon != null) {
+                        trailingIcon()
+                    }
+                }
+            }
+
+        )
+
+        if (borderType == BorderType.ERROR && errorMessage != null) {
+            Text(
+                text = errorMessage,
+                style = MaterialTheme.typography.titleSmall.copy(color = MaterialTheme.colorScheme.error),
+                modifier = Modifier.padding(top = 4.dp, start = 2.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun CleanableInputField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onClear: () -> Unit = { onValueChange("") },
+    placeholder: String = "",
+    validateInput: ((String) -> BorderType)? = null,
+    errorMessage: String? = null,
+    maxLength: Int? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None
+) {
+    BasicInputField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = placeholder,
+        validateInput = validateInput,
+        errorMessage = errorMessage,
+        maxLength = maxLength,
+        visualTransformation = visualTransformation,
+        trailingIcon = {
+            if (value.isNotEmpty()) {
+                DeleteButton(
+                    onClick = onClear,
+                    style = DeleteButtonStyle.DEFAULT
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun SearchInputField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    placeholder: String = "",
+) {
+    BasicInputField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = placeholder,
+        backgroundColor = MaterialTheme.colorScheme.surfaceVariant,
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+        trailingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = "Search",
+                modifier = Modifier
+                    .size(20.dp)
+                    .clickable { onSearch() },
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun InputFieldPreview() {
+    var text by remember { mutableStateOf("") }
+
+    PhraseTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(10.dp)
+        ) {
+            BasicInputField(
+                value = text,
+                onValueChange = { text = it },
+                validateInput = { _ ->
+                    BorderType.NORMAL
+                },
+                singleLine = false,
+                placeholder = "내용을 입력해주세요.",
+                modifier = Modifier
+                    .size(width = 500.dp, height = 300.dp)
+            )
+
+            BasicInputField(
+                value = text,
+                onValueChange = { text = it },
+                validateInput = { input ->
+                    when {
+                        input.isEmpty() -> BorderType.NORMAL
+                        input.length > 10 -> BorderType.ERROR // 길이가 10자를 초과하면 에러
+                        else -> BorderType.SUCCESS // 그 외는 성공
+                    }
+                },
+                errorMessage = "입력값이 너무 깁니다.",
+                placeholder = "닉네임을 입력해주세요.",
+            )
+
+            BasicInputField(
+                value = text,
+                onValueChange = { text = it },
+                validateInput = { input ->
+                    when {
+                        input.isEmpty() -> BorderType.NORMAL
+                        input.length > 10 -> BorderType.ERROR // 길이가 10자를 초과하면 에러
+                        else -> BorderType.SUCCESS // 그 외는 성공
+                    }
+                },
+                errorMessage = "입력값이 너무 깁니다.",
+                placeholder = "비밀번호를 입력해주세요.",
+                visualTransformation = PasswordVisualTransformation()
+            )
+
+            CleanableInputField(
+                value = text,
+                onValueChange = { text = it },
+                validateInput = { input ->
+                    when {
+                        input.isEmpty() -> BorderType.NORMAL
+                        input.length > 10 -> BorderType.ERROR // 길이가 10자를 초과하면 에러
+                        else -> BorderType.SUCCESS // 그 외는 성공
+                    }
+                },
+                errorMessage = "입력값이 너무 깁니다.",
+                placeholder = "닉네임을 입력해주세요."
+            )
+
+            SearchInputField(
+                value = text,
+                onValueChange = { text = it },
+                onSearch = { /* Search action */ },
+                placeholder = "태그를 검색해볼 수 있어요."
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/umc/phrase/commons/ui/theme/Color.kt
+++ b/app/src/main/java/com/umc/phrase/commons/ui/theme/Color.kt
@@ -1,11 +1,34 @@
-package com.umc.phrase.ui.theme
+package com.umc.phrase.commons.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Primary Colors
+val Blue500 = Color(0xFF3A76F0)              // Light - Primary
+val Blue50 = Color(0xFFFFFFFF)               // Light - onPrimary
+val Blue200 = Color(0xFFDCE6FA)              // Light - PrimaryContainer
+val Blue700 = Color(0xFF1B3A70)              // Light - onPrimaryContainer
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+
+// Secondary Colors
+val Purple500 = Color(0xFFB88CFF)            // Light - Secondary
+val Purple50 = Color(0xFFFFFFFF)             // Light - onSecondary
+val Purple200 = Color(0xFFEAD9FF)            // Light - SecondaryContainer
+val Purple700 = Color(0xFF3A1A5E)            // Light - onSecondaryContainer
+
+
+// Background and Surface
+val Gray50 = Color(0xFFFDFDFD)               // Light - Background
+val Gray900 = Color(0xFF2C2C2C)              // Light - onBackground
+val Gray100 = Color(0xFFFFFFFF)              // Light - Surface
+val Gray700 = Color(0xFF4F4F4F)              // Light - onSurface
+val Gray200 = Color(0xFFF5F5F5)              // Light - SurfaceVariant
+val Gray500 = Color(0xFF5D5D5D)              // Light - onSurfaceVariant
+
+// Outline
+val Gray300 = Color(0xFFE0E0E0)              // Light - Outline
+
+// Error Colors
+val Red500 = Color(0xFFD32F2F)               // Light - Error
+val Red50 = Color(0xFFFFFFFF)                // Light - onError
+val Red200 = Color(0xFFFFDAD4)               // Light - ErrorContainer
+val Red700 = Color(0xFF680000)               // Light - onErrorContainer

--- a/app/src/main/java/com/umc/phrase/commons/ui/theme/Theme.kt
+++ b/app/src/main/java/com/umc/phrase/commons/ui/theme/Theme.kt
@@ -1,57 +1,37 @@
-package com.umc.phrase.ui.theme
+package com.umc.phrase.commons.ui.theme
 
-import android.app.Activity
-import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = Blue500,
+    onPrimary = Blue50,
+    primaryContainer = Blue200,
+    onPrimaryContainer = Blue700,
+    secondary = Purple500,
+    onSecondary = Purple50,
+    secondaryContainer = Purple200,
+    onSecondaryContainer = Purple700,
+    background = Gray50,
+    onBackground = Gray900,
+    surface = Gray100,
+    onSurface = Gray700,
+    surfaceVariant = Gray200,
+    onSurfaceVariant = Gray500,
+    outline = Gray300,
+    error = Red500,
+    onError = Red50,
+    errorContainer = Red200,
+    onErrorContainer = Red700
 )
 
 @Composable
 fun PhraseTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
-
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = LightColorScheme,
         typography = Typography,
         content = content
     )

--- a/app/src/main/java/com/umc/phrase/commons/ui/theme/Type.kt
+++ b/app/src/main/java/com/umc/phrase/commons/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.umc.phrase.ui.theme
+package com.umc.phrase.commons.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
@@ -6,29 +6,95 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
 val Typography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 20.sp,
+        lineHeight = 28.sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 18.sp,
+        lineHeight = 26.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 16.sp,
+        lineHeight = 19.sp
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 20.sp,
+        lineHeight = 28.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 18.sp,
+        lineHeight = 22.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 16.sp,
+        lineHeight = 19.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 17.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 14.sp
+    ),
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
+        lineHeight = 24.sp
+    ),
+    bodyMedium = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
+        fontSize = 14.sp,
+        lineHeight = 17.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 18.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Light,
+        fontSize = 16.sp,
+        lineHeight = 24.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Light,
+        fontSize = 14.sp,
+        lineHeight = 17.sp
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
+        fontWeight = FontWeight.Light,
+        fontSize = 12.sp,
+        lineHeight = 14.sp
     )
-    */
 )


### PR DESCRIPTION
## #⃣ 연관된 이슈
- close #1 

## 📝 작업 내용
- [x] 공통 컬러칩 및 텍스트 스타일 정의 (Color.kt, Theme.kt, Typography.kt 파일)
  ![design-system](https://github.com/user-attachments/assets/dd2f4280-b9aa-4db0-9a28-24755fca70cd)
  - 기존 디자인에서 사용하는 컬러들을 Material 테마에서 사용하는 컬러들에 대하여 정리하였습니다. (primary, secondary, surface, background, error)
  - 글꼴 스타일 또한, Material 테마에서 사용하는 글꼴 스타일에 맞추어 정리하였습니다.

- [x] Button 컴포저블 구현
  - Material3에서 제공하는 Button 컴포저블을 커스텀하여 Phrase 앱에서 사용하는 기본 버튼(BasicButton), 보조 버튼(SecondaryButton)을 구현해두었습니다. 버튼에 그림자 속성을 주는 상황은 없어서 기본 Button 컴포저블만을 이용하여 커스텀하였고 (추후 그림자 속성이 추가된다면 ElevatedButton을 사용한다거나 구현해 둔 버튼 컴포저블에 elevation 속성을 추가하면 될 것 같습니다.) 사용 예시도 코드로 넣어두었습니다.
  - Material3에서 제공하는 Button 컴포저블의 기본 컬러 조합과 Phrase 앱에서 사용하는 버튼의 컬러 조합이 다른 부분이 있어 해당 속성 값을 커스텀할 수 있도록 설정하였습니다. (기본 값은 primary 설정에 맞추어 구현해두었습니다.)
  - 버튼의 shape 모양 또한, radius 10dp에 해당하는 모양으로 구현해두었습니다.
  - 버튼에 따라 textStyle이 달라지는 부분도 있어 기본 값은 displayMedium에 해당하는 값으로 설정해두고 상황에 맞추어 수정 가능하게 구현하였습니다.
  - SecondaryButton은 구현한 BasicButton을 사용하여 컬러칩만 수정되도록 하였습니다.
    ```kotlin
    @Composable
    fun BasicButton(
        text: String,
        modifier: Modifier = Modifier,
        enabled: Boolean = false,
        onClick: () -> Unit,
        colors: ButtonColors = ButtonDefaults.buttonColors(
            containerColor = MaterialTheme.colorScheme.primary,
            contentColor = MaterialTheme.colorScheme.surfaceVariant,
            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
        ),
        textStyle: TextStyle = MaterialTheme.typography.displayMedium
    ) {
        Button(
            onClick = onClick,
            enabled = enabled,
            shape = RoundedCornerShape(10.dp),
            colors = colors,
            modifier = modifier.fillMaxWidth()
        ) {
            Text(
                text = text,
                style = textStyle
            )
        }
    }
    ```

- [x] InputField 컴포저블 구현
  - Phrase에서 사용하는 InputField의 종류로 아래와 같이 구분하였습니다. 이 중 1번에 해당하는 InputField를 기본 InputField로 두고, 2번 3번에 해당하는 컴포저블이 이를 이용할 수 있도록 설계하였습니다. (여기서 기본 InputField의 Border는 없는 것을 기본 값으로 설정했습니다.)
      1. Box border(radius 10)에 텍스트 인풋 란만 있는 타입 (Border 있음)
      2. Box border(radius 10)에 텍스트 인풋 란과 clear 버튼 아이콘이 있는 타입 (Border 있음)
      3. Box border(radius 10)에 텍스트 인풋 란과 search 버튼 아이콘이 있는 타입 (Border 없음)
  - BasicInputField의 커스텀 파라미터
    - `placeholder` : 텍스트 필드의 텍스트가 비어있을 때 힌트처럼 사용할 텍스트
    - `placeholderStyle` : placeholder의 텍스트 스타일
    - `textStyle` : 텍스트의 스타일 (글꼴 크기, 색상)
    - `backgroundColor` : InputField의 배경색, 기본 색상은 surface(#FFFFFF)로 설정
    - `errorMessage` : validation에 실패하였을 때 InputField 아래에 표시할 에러 메시지
    - `trailingIcon` : 텍스트필드 내 아이콘
      ```kotlin
      @Composable
      fun BasicInputField(
          value: String,
          onValueChange: (String) -> Unit,
          modifier: Modifier = Modifier,
          placeholder: String = "",
          placeholderStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
          textStyle: TextStyle = MaterialTheme.typography.titleMedium.copy(color = MaterialTheme.colorScheme.onBackground),
          backgroundColor: Color = MaterialTheme.colorScheme.surface,
          validateInput: ((String) -> BorderType)? = null,
          errorMessage: String? = null,
          maxLength: Int? = null,
          singleLine: Boolean = true,
          trailingIcon: (@Composable () -> Unit)? = null,
          keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
          keyboardActions: KeyboardActions = KeyboardActions.Default,
          visualTransformation: VisualTransformation = VisualTransformation.None
      )
      ```
  - 아이콘이 있는 버전의 InputField (삭제버튼 - CleanableInputField, 검색버튼 - SearchInputField) 들은 BasicInputField를 사용하여 구현하였습니다.
  - 코드에 대한 자세한 설명은 내용이 방대하여 [노션 페이지](https://antique-party-5ae.notion.site/06cbeb7a6f274d878a11b90f2623c71f?pvs=4)에 정리해두었습니다.

### 📸 스크린샷 (선택)
- Button 컴포저블 사용 예시
  <img width="500" alt="스크린샷 2024-12-05 오전 1 30 06" src="https://github.com/user-attachments/assets/b239d89d-a12e-42fb-980a-1fdfbfe65738">
  <img width="300" alt="스크린샷 2024-12-05 오전 1 30 51" src="https://github.com/user-attachments/assets/7470c65c-414d-4aa2-b415-21fa0884ba97">
- InputField 컴포저블 사용 예시
  <img width="200" alt="스크린샷 2024-12-05 오전 1 34 53" src="https://github.com/user-attachments/assets/5fc01793-e843-48ac-836a-e90b2977b5e4"> <img width="200" alt="스크린샷 2024-12-05 오전 1 35 23" src="https://github.com/user-attachments/assets/d9ffa92f-0bae-4dd5-803a-725e9f5ea500"> <img width="200" alt="스크린샷 2024-12-05 오전 1 36 51" src="https://github.com/user-attachments/assets/72f5d028-fc3f-4224-9278-248a8e150c11">


## 💬 리뷰 요구사항(선택)
- 공통 컴포넌트들을 개발하며 사용하기에 편리해 보이는지, 추가적으로 커스텀 변수로 넣었으면 좋을 것 같은 값들이 있으면 말씀해주세요!
- 노션 [디자인 시스템을 적용해보자!](https://antique-party-5ae.notion.site/06cbeb7a6f274d878a11b90f2623c71f?pvs=4) 페이지에 적어두긴 했는데 validateInput에 따라 border 색상이 변화할 때 textColor도 같이 변화하는 것이 좋을지 그대로 동일한 색상 값으로 두는 것이 좋을지 의견 주세요! (추가로 해당 페이지 읽어보시면서 이해가 되지 않는 부분이 있다면 어느 부분이 설명이 부족한 것 같은지 말씀해주세요!)
- 기본 컴포저블 네이밍이 좀 구린 것 같아서 좋은 의견 있으시면 남겨주세욥,,
